### PR TITLE
fix:ヘルパーで作成されるlinkのpathがhttpsになってしまう問題

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -16,7 +16,8 @@ class AppServiceProvider extends ServiceProvider
         //文字列の最大文字数をお191文字に限定する設定
         \Schema::defaultStringLength(191);
         //アプリ内のリンクをhttpsで生成する設定
-        \URL::forceScheme('https');
+        // \URL::forceScheme('https');
+        \URL::forceScheme('http');
     }
 
     /**


### PR DESCRIPTION
#1 

環境変数かなにかを利用して、開発環境か本番で切り替える必要がある

開発環境：http
本番環境：https